### PR TITLE
Modified spacing; 1 year is now one gap instead of one tick

### DIFF
--- a/src/components/coverageBar.js
+++ b/src/components/coverageBar.js
@@ -36,9 +36,13 @@ var CoverageBar = React.createClass({
   },
 
   makeCoverageBar: function(barStart, barEnd, id) {
+    var tooltip = barStart + " to " + barEnd;
+
     var start = this.props.min;
-    var end = this.props.max;
+    var end = this.props.max + this.props.stepSize;
     var width = this.props.width;
+
+    barEnd += this.props.stepSize;
 
     var range = end - start;
     var barRange = barEnd - barStart;
@@ -52,7 +56,7 @@ var CoverageBar = React.createClass({
     return (
       <rect
         key={"coverageBar" + id}
-        data-ot={barStart + " to " + barEnd}
+        data-ot={tooltip}
         data-ot-show-effect-duration="0"
         x={barX}
         y={this.props.y}

--- a/src/components/slider.js
+++ b/src/components/slider.js
@@ -6,7 +6,7 @@ module.exports = React.createClass({
     var x = this.props.x;
     var value = this.props.valueLookup.byLocation[x];
 
-    return { x: x, value: value };
+    return { x: x };
   },
 
   consts: {
@@ -18,6 +18,7 @@ module.exports = React.createClass({
     return {
       height: 60,
       handleSize: 10,
+      valueOffset: 0,
       onDrag: function(value) {},
       onRelease: function(value) {}
     };
@@ -35,14 +36,14 @@ module.exports = React.createClass({
       })
       .on('dragmove', function (event) {
         var x = event.pageX;
-        var value = self.props.valueLookup.byLocation[x];
+        var value = self.props.valueLookup.byLocation[x] + self.props.valueOffset;
 
-        self.setState({x: x, value: value});
+        self.setState({x: x});
         self.props.onDrag(value);
       })
       .on('dragend', function (event) {
         var x = event.pageX;
-        var value = self.props.valueLookup.byLocation[x];
+        var value = self.props.valueLookup.byLocation[x] + self.props.valueOffset;
 
         self.props.onRelease(value);
       });
@@ -109,6 +110,8 @@ module.exports = React.createClass({
       leftX + "," + baseY + " " +
       leftX + "," + topY;
 
+    var value = this.props.valueLookup.byLocation[x] + this.props.valueOffset;
+
     return (
       <g className="rf-value-indicator">
         <polyline
@@ -127,7 +130,7 @@ module.exports = React.createClass({
           fontSize={this.props.fontSize}
           fill="red"
           className="rf-label rf-value-indicator-label">
-          {this.state.value}
+          {value}
         </text>
       </g>
     )

--- a/src/mixins/calculatedPropertyMixin.js
+++ b/src/mixins/calculatedPropertyMixin.js
@@ -63,7 +63,8 @@ var PropertyCalculatorMixin = {
   },
 
   calcStepCount: function(props, state) {
-    return (state.max - state.min) / props.stepSize;
+    //+1 due to start/end not being able to overlap
+    return (state.max - state.min) / props.stepSize + 1;
   },
 
   calcBarBottom: function(props, state) {

--- a/src/mixins/componentMakerMixin.js
+++ b/src/mixins/componentMakerMixin.js
@@ -96,7 +96,7 @@ var ComponentMakerMixin = {
 
   makeSliders: function(snapGrid) {
     var leftX = this.valueLookup.byValue[this.state.start];
-    var rightX = this.valueLookup.byValue[this.state.end];
+    var rightX = this.valueLookup.byValue[this.state.end + this.props.stepSize];
 
     var valueLookup = this.valueLookup;
 
@@ -107,10 +107,10 @@ var ComponentMakerMixin = {
       var snapObject = snapGrid[key];
       var x = snapObject.x;
 
-      if(x <= valueLookup.byValue[this.state.end]) {
+      if(x < rightX) {
         startSnapGrid.push(snapObject);
       }
-      if(x >= valueLookup.byValue[this.state.start]) {
+      if(x > leftX) {
         endSnapGrid.push(snapObject);
       }
     }
@@ -140,6 +140,7 @@ var ComponentMakerMixin = {
         fontSize={this.consts.textSize}
         snapGrid={endSnapGrid}
         valueLookup={valueLookup}
+        valueOffset={-this.props.stepSize}
         onDrag={this.onDragRangeEnd}
         onRelease={this.onReleaseRangeEnd}/>
     );
@@ -230,6 +231,7 @@ var ComponentMakerMixin = {
           max={this.state.max}
           coverage={data.coverage}
           dashSize={dashSize}
+          stepSize={this.props.stepSize}
           textMargin={this.consts.textMargin}
           label={this.truncateText(label, this.consts.labelCharacterLimit)}
           tooltip={dataText}/>
@@ -375,7 +377,7 @@ var ComponentMakerMixin = {
     var startX = 0;
     var startWidth = this.valueLookup.byValue[this.state.start];
 
-    var endX = this.valueLookup.byValue[this.state.end];
+    var endX = this.valueLookup.byValue[this.state.end + this.props.stepSize];
     var endWidth = this.barX + this.props.barWidth - endX;
 
     if(this.needsScrollBar) {
@@ -410,7 +412,7 @@ var ComponentMakerMixin = {
 
   makeUnselectedOverlay: function() {
     var startX = this.barX;
-    var endX = this.valueLookup.byValue[this.state.end];
+    var endX = this.valueLookup.byValue[this.state.end + this.props.stepSize];
     var y = this.barBottom;
 
     var startWidth = this.valueLookup.byValue[this.state.start] - this.barX;


### PR DESCRIPTION
Single years in the coverage bar now show as a small block instead of a vertical line.