### PR TITLE
Added checks to ensure no negative width/height

### DIFF
--- a/lib/mixins/calculatedPropertyMixin.js
+++ b/lib/mixins/calculatedPropertyMixin.js
@@ -18,15 +18,19 @@ var PropertyCalculatorMixin = {
 
   //the width of the visible parts of the component
   calcComponentWidth: function(props, state) {
-    return this.calcFullComponentWidth(props, state) -
+    var width = this.calcFullComponentWidth(props, state) -
       this.consts.marginLeft -
       this.consts.marginRight;
+
+    return Math.max(width, 0);
   },
 
   calcCoverageWidth: function(props, state) {
-    return this.calcComponentWidth(props, state) -
+    var width = this.calcComponentWidth(props, state) -
       this.calcScrollBarWidth(props, state) -
       this.props.labelColumnWidth;
+
+    return Math.max(width, 0)
   },
 
   calcCoverageHeight: function(props, state) {
@@ -72,11 +76,13 @@ var PropertyCalculatorMixin = {
   },
 
   calcAllocatedHeight: function(props, state) {
-    return props.height -
+    var height = props.height -
       this.consts.marginTop - 
       props.headerBarHeight -
       this.consts.coverageBarMargin/2 -
       this.consts.marginBottom;
+
+    return Math.max(height, 0);
   },
 
   calcNeedsScrollBar: function(props, state) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-range-finder",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "scripts": {
     "test": "eslint lib/ spec/ && ./node_modules/karma/bin/karma start karma.conf.js",


### PR DESCRIPTION
Related to [Year Selector: "Invalid ngative alue for `<rect>` attribute width=-40"](https://www.wrike.com/open.htm?id=52736545), there wasn't any check in place to make sure that the width of an element didn't go negative. With Sizebox, the width/height starts out negative until after the component mounts, but it checks the width/height *before* it mounts which, at the time, is 0. After applying margins, it ends up with a negative width/height for some elements.